### PR TITLE
Modify API to Not Enforce Same-Origin

### DIFF
--- a/html/api/CheckAuth.php
+++ b/html/api/CheckAuth.php
@@ -3,44 +3,44 @@ require_once 'AuthService.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
-    header('Access-Control-Allow-Methods: GET, OPTIONS');
-    header('Access-Control-Allow-Headers: Content-Type');
-    header('Access-Control-Allow-Credentials: true');
-    exit(0);
+  header('Access-Control-Allow-Origin: http://localhost:3000');
+  header('Access-Control-Allow-Methods: GET, OPTIONS');
+  header('Access-Control-Allow-Headers: Content-Type');
+  header('Access-Control-Allow-Credentials: true');
+  exit(0);
 }
 
 // Only allow GET method
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
-    http_response_code(405);
-    echo '{"error": "Method not allowed"}';
-    exit;
+  http_response_code(405);
+  echo '{"error": "Method not allowed"}';
+  exit;
 }
 
 $currentUser = AuthService::checkAuthentication();
 
 if ($currentUser) {
-    returnWithSuccess(true, $currentUser);
+  returnWithSuccess(true, $currentUser);
 } else {
-    returnWithSuccess(false, null);
+  returnWithSuccess(false, null);
 }
 
 function sendResultInfoAsJson($obj)
 {
-    header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
-    header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
-    header('Access-Control-Allow-Headers: Content-Type');
-    header('Access-Control-Allow-Credentials: true');
-    echo $obj;
+  header('Content-type: application/json');
+  header('Access-Control-Allow-Origin: http://localhost:3000');
+  header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
+  header('Access-Control-Allow-Headers: Content-Type');
+  header('Access-Control-Allow-Credentials: true');
+  echo $obj;
 }
 
 function returnWithSuccess($authenticated, $user)
 {
-    if ($authenticated && $user) {
-        $retValue = '{"authenticated": true, "user": {"id": ' . $user['id'] . ', "firstName": "' . $user['firstName'] . '", "lastName": "' . $user['lastName'] . '", "userName": "' . $user['userName'] . '", "email": "' . $user['email'] . '"}}';
-    } else {
-        $retValue = '{"authenticated": false, "user": null}';
-    }
-    sendResultInfoAsJson($retValue);
+  if ($authenticated && $user) {
+    $retValue = '{"authenticated": true, "user": {"id": ' . $user['id'] . ', "firstName": "' . $user['firstName'] . '", "lastName": "' . $user['lastName'] . '", "userName": "' . $user['userName'] . '", "email": "' . $user['email'] . '"}}';
+  } else {
+    $retValue = '{"authenticated": false, "user": null}';
+  }
+  sendResultInfoAsJson($retValue);
 }

--- a/html/api/CreateContact.php
+++ b/html/api/CreateContact.php
@@ -41,7 +41,7 @@ function getRequestInfo()
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/api/DeleteContact.php
+++ b/html/api/DeleteContact.php
@@ -4,7 +4,7 @@ require_once 'auth_helper.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: DELETE, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');
@@ -59,7 +59,7 @@ if ($conn->connect_error) {
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/api/GetContacts.php
+++ b/html/api/GetContacts.php
@@ -4,7 +4,7 @@ require_once 'auth_helper.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');
@@ -56,7 +56,7 @@ if ($conn->connect_error) {
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/api/Login.php
+++ b/html/api/Login.php
@@ -24,9 +24,10 @@ function sendResultInfoAsJson($obj)
 {
 	// Set the response header to indicate JSON content
 	header('Content-type: application/json');
-	header('Access-Control-Allow-Origin: *');
+	header('Access-Control-Allow-Origin: http://localhost:3000');
 	header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
 	header('Access-Control-Allow-Headers: Content-Type');
+	header('Access-Control-Allow-Credentials: true');
 	// Output the JSON string
 	echo $obj;
 }

--- a/html/api/Logout.php
+++ b/html/api/Logout.php
@@ -3,7 +3,7 @@ require_once 'AuthService.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: DELETE, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');
@@ -23,7 +23,7 @@ returnWithSuccess($result['message']);
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/api/Register.php
+++ b/html/api/Register.php
@@ -53,6 +53,9 @@ function sendResultInfoAsJson($obj)
 {
     // Set the response header to indicate JSON content
     header('Content-type: application/json');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Headers: Content-Type');
     // Output the JSON string
     echo $obj;
 }

--- a/html/api/SearchContacts.php
+++ b/html/api/SearchContacts.php
@@ -4,7 +4,7 @@ require_once 'auth_helper.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');
@@ -61,7 +61,7 @@ if ($conn->connect_error) {
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/api/UpdateContact.php
+++ b/html/api/UpdateContact.php
@@ -4,7 +4,7 @@ require_once 'auth_helper.php';
 
 // Handle OPTIONS request for CORS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: PUT, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');
@@ -100,7 +100,7 @@ function getRequestInfo()
 function sendResultInfoAsJson($obj)
 {
     header('Content-type: application/json');
-    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Origin: http://localhost:3000');
     header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
     header('Access-Control-Allow-Headers: Content-Type');
     header('Access-Control-Allow-Credentials: true');

--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <link rel="stylesheet" href="css/dashboard.css" />
+  <script src="js/config.js"></script>
+  <script src="js/util.js"></script>
   <script src="js/auth.js"></script>
 </head>
 
@@ -16,7 +18,7 @@
         <button id="logoutButton" onclick="logout()">Logout</button>
       </div>
     </div>
-    
+
     <div id="content">
       <div id="welcomeMessage">
         <h2>Welcome to your Contact Manager!</h2>

--- a/html/index.html
+++ b/html/index.html
@@ -1,8 +1,11 @@
+<!DOCTYPE html>
 <html>
 
 <head>
   <meta charset="utf-8" />
   <link rel="stylesheet" href="css/index.css" />
+  <script src="js/config.js"></script>
+  <script src="js/util.js"></script>
   <script src="js/auth.js"></script>
 </head>
 

--- a/html/js/auth.js
+++ b/html/js/auth.js
@@ -6,7 +6,7 @@ window.addEventListener("DOMContentLoaded", function() {
 });
 
 function checkAuthStatus() {
-  fetch("/api/CheckAuth.php", {
+  fetch(window.apiEndpoint("CheckAuth.php"), {
     method: "GET",
     credentials: "include"
   })
@@ -79,7 +79,7 @@ function handleLogin(event) {
   submitButton.textContent = "Signing in...";
   submitButton.disabled = true;
 
-  fetch("/api/Login.php", {
+  fetch(window.apiEndpoint("Login.php"), {
     method: "POST",
     credentials: "include",
     headers: {
@@ -108,7 +108,7 @@ function handleLogin(event) {
 
 // Logout function
 function logout() {
-  fetch("/api/Logout.php", {
+  fetch(window.apiEndpoint("Logout.php"), {
     method: "DELETE",
     credentials: "include"
   })
@@ -183,7 +183,7 @@ function handleRegister(event) {
   submitButton.textContent = "Creating Account...";
   submitButton.disabled = true;
 
-  fetch("/api/Register.php", {
+  fetch(window.apiEndpoint("Register.php"), {
     method: "POST",
     credentials: "include",
     headers: {

--- a/html/js/config.js
+++ b/html/js/config.js
@@ -1,0 +1,7 @@
+const config = {
+  // NOTE: Add dash at the end like god intended!
+  BASE_URL: "http://165.232.128.10/api/"
+}
+
+// Make available
+window.config = config

--- a/html/js/contacts.js
+++ b/html/js/contacts.js
@@ -1,213 +1,213 @@
 // Contact management functions with proper HTTP methods
 
 // Get all contacts for the authenticated user
-function getContacts(userId = null) {
-    let url = '/api/GetContacts.php';
-    if (userId) {
-        url += '?user_id=' + userId;
-    }
-    
-    return fetch(url, {
-        method: 'GET',
-        credentials: 'include'
-    })
+async function getContacts(userId = null) {
+  let url = window.apiEndpoint('GetContacts.php');
+  if (userId) {
+    url += '?user_id=' + userId;
+  }
+
+  return fetch(url, {
+    method: 'GET',
+    credentials: 'include'
+  })
     .then(response => response.json());
 }
 
 // Create a new contact
-function createContact(contactData) {
-    return fetch('/api/CreateContact.php', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(contactData)
-    })
+async function createContact(contactData) {
+  return fetch(window.apiEndpoint('CreateContact.php'), {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(contactData)
+  })
     .then(response => response.json());
 }
 
 // Update an existing contact
-function updateContact(contactId, contactData, userId = null) {
-    const updateData = {
-        contact_id: contactId,
-        ...contactData
-    };
-    
-    if (userId) {
-        updateData.user_id = userId;
-    }
-    
-    return fetch('/api/UpdateContact.php', {
-        method: 'PUT',
-        credentials: 'include',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(updateData)
-    })
+async function updateContact(contactId, contactData, userId = null) {
+  const updateData = {
+    contact_id: contactId,
+    ...contactData
+  };
+
+  if (userId) {
+    updateData.user_id = userId;
+  }
+
+  return fetch(window.apiEndpoint('UpdateContact.php'), {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(updateData)
+  })
     .then(response => response.json());
 }
 
 // Delete a contact
-function deleteContact(contactId, userId = null) {
-    let url = '/api/DeleteContact.php?contact_id=' + contactId;
-    if (userId) {
-        url += '&user_id=' + userId;
-    }
-    
-    return fetch(url, {
-        method: 'DELETE',
-        credentials: 'include'
-    })
+async function deleteContact(contactId, userId = null) {
+  let url = window.apiEndpoint('DeleteContact.php') + '?contact_id=' + contactId;
+  if (userId) {
+    url += '&user_id=' + userId;
+  }
+
+  return fetch(url, {
+    method: 'DELETE',
+    credentials: 'include'
+  })
     .then(response => response.json());
 }
 
 // Search contacts
-function searchContacts(searchTerm, userId = null) {
-    let url = '/api/SearchContacts.php?search_term=' + encodeURIComponent(searchTerm);
-    if (userId) {
-        url += '&user_id=' + userId;
-    }
-    
-    return fetch(url, {
-        method: 'GET',
-        credentials: 'include'
-    })
+async function searchContacts(searchTerm, userId = null) {
+  let url = window.apiEndpoint('SearchContacts.php') + '?search_term=' + encodeURIComponent(searchTerm);
+  if (userId) {
+    url += '&user_id=' + userId;
+  }
+
+  return fetch(url, {
+    method: 'GET',
+    credentials: 'include'
+  })
     .then(response => response.json());
 }
 
 // Example usage functions for UI integration
 
 // Load and display contacts
-function loadContacts() {
-    getContacts()
-        .then(data => {
-            if (data.success) {
-                displayContacts(data.contacts);
-            } else {
-                showError(data.error || 'Failed to load contacts');
-            }
-        })
-        .catch(error => {
-            console.error('Error loading contacts:', error);
-            showError('Failed to load contacts');
-        });
+async function loadContacts() {
+  getContacts()
+    .then(data => {
+      if (data.success) {
+        displayContacts(data.contacts);
+      } else {
+        showError(data.error || 'Failed to load contacts');
+      }
+    })
+    .catch(error => {
+      console.error('Error loading contacts:', error);
+      showError('Failed to load contacts');
+    });
 }
 
 // Handle contact form submission
 function handleContactForm(event) {
-    event.preventDefault();
-    
-    const formData = new FormData(event.target);
-    const contactData = {
-        first_name: formData.get('first_name'),
-        last_name: formData.get('last_name'),
-        email: formData.get('email'),
-        phone_number: formData.get('phone_number')
-    };
-    
-    const contactId = formData.get('contact_id');
-    
-    if (contactId) {
-        // Update existing contact
-        updateContact(contactId, contactData)
-            .then(data => {
-                if (data.success) {
-                    showSuccess('Contact updated successfully');
-                    loadContacts();
-                    event.target.reset();
-                } else {
-                    showError(data.error || 'Failed to update contact');
-                }
-            })
-            .catch(error => {
-                console.error('Error updating contact:', error);
-                showError('Failed to update contact');
-            });
-    } else {
-        // Create new contact
-        createContact(contactData)
-            .then(data => {
-                if (data.success) {
-                    showSuccess('Contact created successfully');
-                    loadContacts();
-                    event.target.reset();
-                } else {
-                    showError(data.error || 'Failed to create contact');
-                }
-            })
-            .catch(error => {
-                console.error('Error creating contact:', error);
-                showError('Failed to create contact');
-            });
-    }
+  event.preventDefault();
+
+  const formData = new FormData(event.target);
+  const contactData = {
+    first_name: formData.get('first_name'),
+    last_name: formData.get('last_name'),
+    email: formData.get('email'),
+    phone_number: formData.get('phone_number')
+  };
+
+  const contactId = formData.get('contact_id');
+
+  if (contactId) {
+    // Update existing contact
+    updateContact(contactId, contactData)
+      .then(data => {
+        if (data.success) {
+          showSuccess('Contact updated successfully');
+          loadContacts();
+          event.target.reset();
+        } else {
+          showError(data.error || 'Failed to update contact');
+        }
+      })
+      .catch(error => {
+        console.error('Error updating contact:', error);
+        showError('Failed to update contact');
+      });
+  } else {
+    // Create new contact
+    createContact(contactData)
+      .then(data => {
+        if (data.success) {
+          showSuccess('Contact created successfully');
+          loadContacts();
+          event.target.reset();
+        } else {
+          showError(data.error || 'Failed to create contact');
+        }
+      })
+      .catch(error => {
+        console.error('Error creating contact:', error);
+        showError('Failed to create contact');
+      });
+  }
 }
 
 // Handle contact deletion
 function handleDeleteContact(contactId) {
-    if (confirm('Are you sure you want to delete this contact?')) {
-        deleteContact(contactId)
-            .then(data => {
-                if (data.success) {
-                    showSuccess('Contact deleted successfully');
-                    loadContacts();
-                } else {
-                    showError(data.error || 'Failed to delete contact');
-                }
-            })
-            .catch(error => {
-                console.error('Error deleting contact:', error);
-                showError('Failed to delete contact');
-            });
-    }
+  if (confirm('Are you sure you want to delete this contact?')) {
+    deleteContact(contactId)
+      .then(data => {
+        if (data.success) {
+          showSuccess('Contact deleted successfully');
+          loadContacts();
+        } else {
+          showError(data.error || 'Failed to delete contact');
+        }
+      })
+      .catch(error => {
+        console.error('Error deleting contact:', error);
+        showError('Failed to delete contact');
+      });
+  }
 }
 
 // Handle search
 function handleSearch(event) {
-    const searchTerm = event.target.value.trim();
-    
-    if (searchTerm.length === 0) {
-        loadContacts();
-        return;
-    }
-    
-    if (searchTerm.length >= 2) {
-        searchContacts(searchTerm)
-            .then(data => {
-                if (data.success) {
-                    displayContacts(data.contacts);
-                    showSearchInfo(data.results_count, data.search_term);
-                } else {
-                    showError(data.error || 'Search failed');
-                }
-            })
-            .catch(error => {
-                console.error('Error searching contacts:', error);
-                showError('Search failed');
-            });
-    }
+  const searchTerm = event.target.value.trim();
+
+  if (searchTerm.length === 0) {
+    loadContacts();
+    return;
+  }
+
+  if (searchTerm.length >= 2) {
+    searchContacts(searchTerm)
+      .then(data => {
+        if (data.success) {
+          displayContacts(data.contacts);
+          showSearchInfo(data.results_count, data.search_term);
+        } else {
+          showError(data.error || 'Search failed');
+        }
+      })
+      .catch(error => {
+        console.error('Error searching contacts:', error);
+        showError('Search failed');
+      });
+  }
 }
 
 // Utility functions for UI (implement based on your HTML structure)
 function displayContacts(contacts) {
-    console.log('Displaying contacts:', contacts);
-    // Implement based on your UI needs
+  console.log('Displaying contacts:', contacts);
+  // Implement based on your UI needs
 }
 
 function showError(message) {
-    console.error('Error:', message);
-    // Implement error display
+  console.error('Error:', message);
+  // Implement error display
 }
 
 function showSuccess(message) {
-    console.log('Success:', message);
-    // Implement success display
+  console.log('Success:', message);
+  // Implement success display
 }
 
 function showSearchInfo(count, term) {
-    console.log(`Found ${count} results for "${term}"`);
-    // Implement search info display
+  console.log(`Found ${count} results for "${term}"`);
+  // Implement search info display
 }
 
 // Make functions available globally

--- a/html/js/util.js
+++ b/html/js/util.js
@@ -1,0 +1,6 @@
+function apiEndpoint(endpoint) {
+  return window.config.BASE_URL + endpoint
+}
+
+// Make available
+window.apiEndpoint = apiEndpoint

--- a/html/register.html
+++ b/html/register.html
@@ -1,8 +1,11 @@
+<!DOCTYPE html>
 <html>
 
 <head>
   <meta charset="utf-8" />
   <link rel="stylesheet" href="css/index.css" />
+  <script src="js/config.js"></script>
+  <script src="js/util.js"></script>
   <script src="js/auth.js"></script>
 </head>
 


### PR DESCRIPTION
CORS enforces same-origin requests by default, but to test our API using a local live server, we must call the production API from the local live server which requires us to violate same-origin. This PR:

**1. Modifies our API's header settings to not enforce same-origin, allowing a local live server (or anywhere!) to call the production API.**
**2. Adds a `config.js` file that allows us to modify the API's base URL; normally it's `/api/...`, but since on a local live server we might want to talk to the real server, we will need to modify it to the actual base URL for this to work.**

**TLDR: API was modified to allow a local live server to call it in order to facilitate local testing, which requires same-origin violation.**

> This is probably really bad security practice but we don't care for the purposes of this!